### PR TITLE
Make it a little easier to study the command

### DIFF
--- a/Tests/PackageCollectionGeneratorExecutableTests/PackageCollectionGenerateTests.swift
+++ b/Tests/PackageCollectionGeneratorExecutableTests/PackageCollectionGenerateTests.swift
@@ -81,8 +81,14 @@ final class PackageCollectionGenerateTests: XCTestCase {
             // `tmpDir` is where we extract the repos so use it as the working directory so we won't actually doing any cloning
             let workingDirectoryPath = tmpDir
 
-            XCTAssert(try executeCommand(command: "package-collection-generate --verbose \(inputFilePath.pathString) \(outputFilePath.pathString) --working-directory-path \(workingDirectoryPath.pathString)")
-                .stdout.contains("Package collection saved to \(outputFilePath.pathString)"))
+            let cmd = try PackageCollectionGenerate.parse([
+                "--verbose",
+                inputFilePath.pathString,
+                outputFilePath.pathString,
+                "--working-directory-path",
+                workingDirectoryPath.pathString
+            ])
+            try cmd.run()
 
             let expectedPackages = [
                 Model.Collection.Package(


### PR DESCRIPTION
Hi @yim-lee , I've had a first look into incorporating the collection generator into the SPI and while doing so I found it helpful to change the end-to-end test from a shell-out command into a parsed command that calls `run()`. That way it was easier to step through it with the debugger - or am I missing a way that could be done with the shell-out command?

I can see how that isn't quite a true end-to-end test anymore though, so maybe that's not something you'd like to change.

Just a thought!