### PR TITLE
Add summary and createdAt to package version

### DIFF
--- a/Sources/PackageCollectionGenerator/Models/PackageCollectionExtensions.swift
+++ b/Sources/PackageCollectionGenerator/Models/PackageCollectionExtensions.swift
@@ -19,7 +19,7 @@ extension PackageCollectionModel.V1.Collection: CustomStringConvertible {
         """
         Collection {
             name=\(self.name),
-            overview=\(self.overview ?? "nil"),
+            overview="\(self.overview ?? "nil")",
             keywords=\(self.keywords.map { "\($0)" } ?? "nil"),
             packages=\(self.packages),
             formatVersion=\(self.formatVersion),
@@ -42,7 +42,7 @@ extension PackageCollectionModel.V1.Collection.Package: CustomStringConvertible 
         """
         Package {
             url=\(self.url),
-            summary=\(self.summary ?? "nil"),
+            summary="\(self.summary ?? "nil")",
             keywords=\(self.keywords.map { "\($0)" } ?? "nil"),
             versions=\(self.versions),
             readmeURL=\(self.readmeURL.map { "\($0)" } ?? "nil"),
@@ -57,10 +57,12 @@ extension PackageCollectionModel.V1.Collection.Package.Version: CustomStringConv
         """
         Version {
                 version=\(self.version),
+                summary="\(self.summary ?? "nil")",
                 manifests=\(self.manifests),
                 defaultToolsVersion=\(self.defaultToolsVersion),
                 verifiedCompatibility=\(self.verifiedCompatibility.map { "\($0)" } ?? "nil"),
-                license=\(self.license.map { "\($0)" } ?? "nil")
+                license=\(self.license.map { "\($0)" } ?? "nil"),
+                createdAt=\(self.createdAt.map { "\($0)" } ?? "nil")
             }
         """
     }

--- a/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
+++ b/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
@@ -205,6 +205,8 @@ public struct PackageCollectionGenerate: ParsableCommand {
         print("Checking out version \(version)", inColor: .yellow, verbose: self.verbose)
         try ShellUtilities.run(Git.tool, "-C", gitDirectoryPath.pathString, "checkout", version)
 
+        let gitTagInfo = try GitUtilities.tagInfo(version, for: gitDirectoryPath)
+
         let defaultManifest = try self.defaultManifest(
             excludedProducts: excludedProducts,
             excludedTargets: excludedTargets,
@@ -216,10 +218,12 @@ public struct PackageCollectionGenerate: ParsableCommand {
 
         return Model.Collection.Package.Version(
             version: version,
+            summary: gitTagInfo?.message,
             manifests: manifests,
             defaultToolsVersion: defaultManifest.toolsVersion,
             verifiedCompatibility: nil,
-            license: nil
+            license: nil,
+            createdAt: gitTagInfo?.createdAt
         )
     }
 

--- a/Tests/PackageCollectionGeneratorExecutableTests/PackageCollectionGenerateTests.swift
+++ b/Tests/PackageCollectionGeneratorExecutableTests/PackageCollectionGenerateTests.swift
@@ -98,6 +98,7 @@ final class PackageCollectionGenerateTests: XCTestCase {
                     versions: [
                         Model.Collection.Package.Version(
                             version: "0.1.0",
+                            summary: nil,
                             manifests: [
                                 "5.2.0": Model.Collection.Package.Version.Manifest(
                                     toolsVersion: "5.2.0",
@@ -109,7 +110,8 @@ final class PackageCollectionGenerateTests: XCTestCase {
                             ],
                             defaultToolsVersion: "5.2.0",
                             verifiedCompatibility: nil,
-                            license: nil
+                            license: nil,
+                            createdAt: nil
                         ),
                     ],
                     readmeURL: nil,
@@ -122,6 +124,7 @@ final class PackageCollectionGenerateTests: XCTestCase {
                     versions: [
                         Model.Collection.Package.Version(
                             version: "0.2.0",
+                            summary: nil,
                             manifests: [
                                 "5.2.0": Model.Collection.Package.Version.Manifest(
                                     toolsVersion: "5.2.0",
@@ -139,10 +142,12 @@ final class PackageCollectionGenerateTests: XCTestCase {
                             ],
                             defaultToolsVersion: "5.2.0",
                             verifiedCompatibility: nil,
-                            license: nil
+                            license: nil,
+                            createdAt: nil
                         ),
                         Model.Collection.Package.Version(
                             version: "0.1.0",
+                            summary: nil,
                             manifests: [
                                 "5.2.0": Model.Collection.Package.Version.Manifest(
                                     toolsVersion: "5.2.0",
@@ -154,7 +159,8 @@ final class PackageCollectionGenerateTests: XCTestCase {
                             ],
                             defaultToolsVersion: "5.2.0",
                             verifiedCompatibility: nil,
-                            license: nil
+                            license: nil,
+                            createdAt: nil
                         ),
                     ],
                     readmeURL: nil,
@@ -167,6 +173,7 @@ final class PackageCollectionGenerateTests: XCTestCase {
                     versions: [
                         Model.Collection.Package.Version(
                             version: "1.0.0",
+                            summary: nil,
                             manifests: [
                                 "5.2.0": Model.Collection.Package.Version.Manifest(
                                     toolsVersion: "5.2.0",
@@ -178,7 +185,8 @@ final class PackageCollectionGenerateTests: XCTestCase {
                             ],
                             defaultToolsVersion: "5.2.0",
                             verifiedCompatibility: nil,
-                            license: nil
+                            license: nil,
+                            createdAt: nil
                         ),
                     ],
                     readmeURL: nil,


### PR DESCRIPTION
Requires https://github.com/apple/swift-package-manager/pull/3266

The `generate` tool will try to obtain message and timestamp for **annotated** tags only. In most use-cases, tag is created as part of a (GitHub) release and is "lightweight", which is the opposite of annotated and the information we get with `git` would not be suitable.