### PR TITLE
Fix compilation error

### DIFF
--- a/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
+++ b/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
@@ -320,6 +320,8 @@ extension PackageCollectionModel.V1.ProductType {
             self = .library(.init(from: libraryType))
         case .executable:
             self = .executable
+        case .extension:
+            self = .extension
         case .test:
             self = .test
         }


### PR DESCRIPTION
New `ProductType.extension` recently introduced in SwiftPM