### PR TITLE
Update PackageCollectionModel.V1.ProductType init extension for `.extension` → `.plugin` renaming

### DIFF
--- a/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
+++ b/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
@@ -321,7 +321,7 @@ extension PackageCollectionModel.V1.ProductType {
         case .executable:
             self = .executable
         case .plugin:
-            self = .extension
+            self = .plugin
         case .test:
             self = .test
         }

--- a/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
+++ b/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
@@ -320,7 +320,7 @@ extension PackageCollectionModel.V1.ProductType {
             self = .library(.init(from: libraryType))
         case .executable:
             self = .executable
-        case .extension:
+        case .plugin:
             self = .extension
         case .test:
             self = .test


### PR DESCRIPTION
Fix a build failure caused by SwiftPM upstream renaming `ProductType.extension` to `ProductType.plugin` in https://github.com/apple/swift-package-manager/pull/3311.

Note that [SwiftPM's `PackageCollectionModel.V1.ProductType`](https://github.com/apple/swift-package-manager/blob/d1ef83796730d76754db58d327e7fd02bc785e97/Sources/PackageCollectionsModel/PackageCollectionModel%2Bv1.swift#L336-L374) hasn't gotten this rename yet and still has `ProductType.extension`, which seems like a mismatch that probably needs to be resolved upstream (and then again here).

/cc @abertelrud @yim-lee 