### PR TITLE
Add --pretty-printed command to package-collection-generate

### DIFF
--- a/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
+++ b/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
@@ -55,6 +55,9 @@ public struct PackageCollectionGenerate: ParsableCommand {
         """)
     private var authToken: [String] = []
 
+    @Flag(name: .long, help: "Format output using friendly indentation and line-breaks.")
+    private var prettyPrinted: Bool = false
+
     @Flag(name: .shortAndLong, help: "Show extra logging for debugging purposes.")
     private var verbose: Bool = false
 
@@ -134,7 +137,7 @@ public struct PackageCollectionGenerate: ParsableCommand {
         try localFileSystem.createDirectory(outputDirectory, recursive: true)
 
         // Write the package collection
-        let jsonEncoder = JSONEncoder.makeWithDefaults(sortKeys: true, prettyPrint: false, escapeSlashes: false)
+        let jsonEncoder = JSONEncoder.makeWithDefaults(sortKeys: true, prettyPrint: prettyPrinted, escapeSlashes: false)
         let jsonData = try jsonEncoder.encode(packageCollection)
         try jsonData.write(to: URL(fileURLWithPath: outputAbsolutePath.pathString))
         print("Package collection saved to \(outputAbsolutePath)", inColor: .cyan, verbose: self.verbose)

--- a/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
+++ b/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
@@ -137,7 +137,7 @@ public struct PackageCollectionGenerate: ParsableCommand {
         try localFileSystem.createDirectory(outputDirectory, recursive: true)
 
         // Write the package collection
-        let jsonEncoder = JSONEncoder.makeWithDefaults(sortKeys: true, prettyPrint: prettyPrinted, escapeSlashes: false)
+        let jsonEncoder = JSONEncoder.makeWithDefaults(sortKeys: true, prettyPrint: self.prettyPrinted, escapeSlashes: false)
         let jsonData = try jsonEncoder.encode(packageCollection)
         try jsonData.write(to: URL(fileURLWithPath: outputAbsolutePath.pathString))
         print("Package collection saved to \(outputAbsolutePath)", inColor: .cyan, verbose: self.verbose)
@@ -145,7 +145,8 @@ public struct PackageCollectionGenerate: ParsableCommand {
 
     private func generateMetadata(for package: PackageCollectionGeneratorInput.Package,
                                   metadataProvider: PackageMetadataProvider,
-                                  jsonDecoder: JSONDecoder) throws -> Model.Collection.Package {
+                                  jsonDecoder: JSONDecoder) throws -> Model.Collection.Package
+    {
         print("Processing Package(\(package.url))", inColor: .cyan, verbose: self.verbose)
 
         // Try to locate the directory where the repository might have been cloned to previously
@@ -199,7 +200,8 @@ public struct PackageCollectionGenerate: ParsableCommand {
     private func generateMetadata(for package: PackageCollectionGeneratorInput.Package,
                                   gitDirectoryPath: AbsolutePath,
                                   metadataProvider: PackageMetadataProvider,
-                                  jsonDecoder: JSONDecoder) throws -> Model.Collection.Package {
+                                  jsonDecoder: JSONDecoder) throws -> Model.Collection.Package
+    {
         var additionalMetadata: PackageBasicMetadata?
         do {
             additionalMetadata = try tsc_await { callback in metadataProvider.get(package.url, callback: callback) }
@@ -260,7 +262,8 @@ public struct PackageCollectionGenerate: ParsableCommand {
                                   excludedProducts: Set<String>,
                                   excludedTargets: Set<String>,
                                   gitDirectoryPath: AbsolutePath,
-                                  jsonDecoder: JSONDecoder) throws -> Model.Collection.Package.Version {
+                                  jsonDecoder: JSONDecoder) throws -> Model.Collection.Package.Version
+    {
         // Check out the git tag
         print("Checking out version \(version)", inColor: .yellow, verbose: self.verbose)
         try ShellUtilities.run(Git.tool, "-C", gitDirectoryPath.pathString, "checkout", version)
@@ -290,7 +293,8 @@ public struct PackageCollectionGenerate: ParsableCommand {
     private func defaultManifest(excludedProducts: Set<String>,
                                  excludedTargets: Set<String>,
                                  gitDirectoryPath: AbsolutePath,
-                                 jsonDecoder: JSONDecoder) throws -> Model.Collection.Package.Version.Manifest {
+                                 jsonDecoder: JSONDecoder) throws -> Model.Collection.Package.Version.Manifest
+    {
         // Run `swift package dump-package` to generate JSON manifest from `Package.swift`
         let manifestJSON = try ShellUtilities.run(ShellUtilities.shell, "-c", "cd \(gitDirectoryPath) && swift package dump-package")
         let manifest = try jsonDecoder.decode(PackageManifest.self, from: manifestJSON.data(using: .utf8) ?? Data())

--- a/Sources/PackageCollectionGenerator/README.md
+++ b/Sources/PackageCollectionGenerator/README.md
@@ -8,7 +8,7 @@ by SwiftPM.
 > swift run package-collection-generate --help
 OVERVIEW: Generate a package collection from the given list of packages.
 
-USAGE: package-collection-generate <input-path> <output-path> [--working-directory-path <working-directory-path>] [--revision <revision>] [--verbose]
+USAGE: package-collection-generate <input-path> <output-path> [--working-directory-path <working-directory-path>] [--revision <revision>] [--auth-token <auth-token> ...] [--pretty-printed] [--verbose]
 
 ARGUMENTS:
   <input-path>            The path to the JSON document containing the list of packages to be processed 
@@ -27,6 +27,7 @@ OPTIONS:
   --auth-token <auth-token>
                           Auth tokens each in the format of type:host:token for retrieving additional package metadata via source
                           hosting platform APIs. Currently only GitHub APIs are supported. An example token would be github:github.com:<TOKEN>.   
+  --pretty-printed        Format output using friendly indentation and line-breaks.
   -v, --verbose           Show extra logging for debugging purposes.
   -h, --help              Show help information.
 ```

--- a/Tests/PackageCollectionGeneratorExecutableTests/PackageCollectionGenerateTests.swift
+++ b/Tests/PackageCollectionGeneratorExecutableTests/PackageCollectionGenerateTests.swift
@@ -26,8 +26,9 @@ final class PackageCollectionGenerateTests: XCTestCase {
     typealias Model = PackageCollectionModel.V1
 
     func test_help() throws {
-        XCTAssert(try executeCommand(command: "package-collection-generate --help")
-            .stdout.contains("USAGE: package-collection-generate <input-path> <output-path> [--working-directory-path <working-directory-path>] [--revision <revision>] [--auth-token <auth-token> ...] [--verbose]"))
+        let help = try executeCommand(command: "package-collection-generate --help").stdout
+        let expectedUsageDescription = "USAGE: package-collection-generate <input-path> <output-path> [--working-directory-path <working-directory-path>] [--revision <revision>] [--auth-token <auth-token> ...] [--pretty-printed] [--verbose]"
+        XCTAssert(help.contains(expectedUsageDescription), "Help did not contain expected usage description, instead it had:\n\(help)")
     }
 
     func test_endToEnd() throws {
@@ -69,20 +70,6 @@ final class PackageCollectionGenerateTests: XCTestCase {
             let inputData = try jsonEncoder.encode(input)
             let inputFilePath = tmpDir.appending(component: "input.json")
             try localFileSystem.writeFileContents(inputFilePath, bytes: ByteString(inputData))
-
-            // Where to write the generated collection
-            let outputFilePath = tmpDir.appending(component: "package-collection.json")
-            // `tmpDir` is where we extract the repos so use it as the working directory so we won't actually doing any cloning
-            let workingDirectoryPath = tmpDir
-
-            let cmd = try PackageCollectionGenerate.parse([
-                "--verbose",
-                inputFilePath.pathString,
-                outputFilePath.pathString,
-                "--working-directory-path",
-                workingDirectoryPath.pathString,
-            ])
-            try cmd.run()
 
             let expectedPackages = [
                 Model.Collection.Package(
@@ -188,15 +175,36 @@ final class PackageCollectionGenerateTests: XCTestCase {
                 ),
             ]
 
-            let jsonDecoder = JSONDecoder.makeWithDefaults()
+            // Run command with both pretty-printed enabled and disabled (which is the default, with no flag).
+            for prettyFlag in ["--pretty-printed", nil] {
+                // Where to write the generated collection
+                let outputFilePath = tmpDir.appending(component: "package-collection\(prettyFlag ?? "").json")
+                // `tmpDir` is where we extract the repos so use it as the working directory so we won't actually doing any cloning
+                let workingDirectoryPath = tmpDir
 
-            // Assert the generated package collection
-            let collectionData = try localFileSystem.readFileContents(outputFilePath).contents
-            let packageCollection = try jsonDecoder.decode(Model.Collection.self, from: Data(collectionData))
-            XCTAssertEqual(input.name, packageCollection.name)
-            XCTAssertEqual(input.overview, packageCollection.overview)
-            XCTAssertEqual(input.keywords, packageCollection.keywords)
-            XCTAssertEqual(expectedPackages, packageCollection.packages)
+                let flags = [
+                    "--verbose",
+                    prettyFlag,
+                    inputFilePath.pathString,
+                    outputFilePath.pathString,
+                    "--working-directory-path",
+                    workingDirectoryPath.pathString,
+                ].compactMap { $0 }
+                let cmd = try PackageCollectionGenerate.parse(flags)
+                try cmd.run()
+
+                let jsonDecoder = JSONDecoder.makeWithDefaults()
+
+                // Assert the generated package collection
+                let collectionData = try localFileSystem.readFileContents(outputFilePath).contents
+                let packageCollection = try jsonDecoder.decode(Model.Collection.self, from: Data(collectionData))
+                XCTAssertEqual(input.name, packageCollection.name)
+                XCTAssertEqual(input.overview, packageCollection.overview)
+                XCTAssertEqual(input.keywords, packageCollection.keywords)
+                XCTAssertEqual(expectedPackages, packageCollection.packages)
+
+                add(XCTAttachment(contentsOfFile: outputFilePath.asURL))
+            }
         }
     }
 


### PR DESCRIPTION
Adds a `--pretty-printed` flag to package-collection-generate that nicely formats the collection output.

Fixes rdar://73019498.