### PR TITLE
Remove -warnings-as-errors flag from docker builds

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -28,7 +28,8 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift test --enable-test-discovery -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"
+    command: /bin/bash -xcl "swift test --enable-test-discovery $${SANITIZER_ARG-}"
+    #command: /bin/bash -xcl "swift test --enable-test-discovery -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"
 
   # util
 


### PR DESCRIPTION
Since SwiftPM has warnings