### PR TITLE
Improve regex for extracting repository name from git URL

### DIFF
--- a/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
+++ b/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
@@ -121,10 +121,10 @@ public struct PackageCollectionGenerate: ParsableCommand {
 
             // Extract directory name from repository URL
             let repositoryURL = package.url.absoluteString
-            let regex = try NSRegularExpression(pattern: "([^/]+)\\.git$", options: .caseInsensitive)
+            let regex = try NSRegularExpression(pattern: #"([^/@]+)[:/]([^:/]+)/([^/.]+)(\.git)?$"#, options: .caseInsensitive)
 
             if let match = regex.firstMatch(in: repositoryURL, options: [], range: NSRange(location: 0, length: repositoryURL.count)) {
-                if let range = Range(match.range(at: 1), in: repositoryURL) {
+                if let range = Range(match.range(at: 3), in: repositoryURL) {
                     let repositoryName = String(repositoryURL[range])
                     print("Extracted repository name from URL: \(repositoryName)", inColor: .green, verbose: self.verbose)
 

--- a/Tests/PackageCollectionGeneratorExecutableTests/PackageCollectionGenerateTests.swift
+++ b/Tests/PackageCollectionGeneratorExecutableTests/PackageCollectionGenerateTests.swift
@@ -199,4 +199,10 @@ final class PackageCollectionGenerateTests: XCTestCase {
             XCTAssertEqual(expectedPackages, packageCollection.packages)
         }
     }
+
+    func test_respositoryName() throws {
+        XCTAssertEqual("FooBar", try PackageCollectionGenerate.repositoryName("https://test.com/testOrg/FooBar.git"))
+        XCTAssertEqual("FooBar", try PackageCollectionGenerate.repositoryName("https://test.com/testOrg/FooBar"))
+        XCTAssertEqual("FooBar", try PackageCollectionGenerate.repositoryName("git@test.com:testOrg/FooBar.git"))
+    }
 }


### PR DESCRIPTION
Motivation:
The subdirectory name used for cloning a repo under the cache directory is extracted from the repo's URL. Currently it only works if the URL contains `.git` suffix.

Modification:
Improve the regex (copied from SwiftPM) so that `.git` suffix is optional.