### PR TITLE
Add 'excludedVersions' to generator input

### DIFF
--- a/Sources/PackageCollectionGenerator/Models/PackageCollectionGeneratorInput.swift
+++ b/Sources/PackageCollectionGenerator/Models/PackageCollectionGeneratorInput.swift
@@ -78,6 +78,11 @@ extension PackageCollectionGeneratorInput {
         /// If not specified, the generator will select from most recent SemVers.
         public let versions: [String]?
 
+        /// Versions to be excluded from the collection.
+        /// If a version is listed in both `versions` and `excludedVersions`, it will be excluded from the collection.
+        /// In other words, `excludedVersions` has higher precedence than `versions`.
+        public let excludedVersions: [String]?
+
         /// Products to be excluded from the collection.
         public let excludedProducts: [String]?
 
@@ -92,6 +97,7 @@ extension PackageCollectionGeneratorInput {
             summary: String? = nil,
             keywords: [String]? = nil,
             versions: [String]? = nil,
+            excludedVersions: [String]? = nil,
             excludedProducts: [String]? = nil,
             excludedTargets: [String]? = nil,
             readmeURL: URL? = nil
@@ -100,6 +106,7 @@ extension PackageCollectionGeneratorInput {
             self.summary = summary
             self.keywords = keywords
             self.versions = versions
+            self.excludedVersions = excludedVersions
             self.excludedProducts = excludedProducts
             self.excludedTargets = excludedTargets
             self.readmeURL = readmeURL
@@ -115,6 +122,7 @@ extension PackageCollectionGeneratorInput.Package: CustomStringConvertible {
                 summary=\(self.summary ?? "nil"),
                 keywords=\(self.keywords.map { "\($0)" } ?? "nil"),
                 versions=\(self.versions.map { "\($0)" } ?? "nil"),
+                excludedVersions=\(self.excludedVersions.map { "\($0)" } ?? "nil"),
                 excludedProducts=\(self.excludedProducts.map { "\($0)" } ?? "nil"),
                 excludedTargets=\(self.excludedTargets.map { "\($0)" } ?? "nil"),
                 readmeURL=\(self.readmeURL.map { "\($0)" } ?? "nil")

--- a/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
+++ b/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
@@ -191,7 +191,15 @@ public struct PackageCollectionGenerate: ParsableCommand {
         }
 
         // Select versions if none specified
-        let versions = try package.versions ?? self.defaultVersions(for: gitDirectoryPath)
+        var versions = try package.versions ?? self.defaultVersions(for: gitDirectoryPath)
+
+        // Remove excluded versions
+        if let excludedVersions = package.excludedVersions {
+            print("Excluding: \(excludedVersions)", inColor: .yellow, verbose: self.verbose)
+            let excludedVersionsSet = Set(excludedVersions)
+            versions = versions.filter { !excludedVersionsSet.contains($0) }
+        }
+
         // Load the manifest for each version and extract metadata
         let packageVersions: [Model.Collection.Package.Version] = versions.compactMap { version in
             do {

--- a/Sources/PackageCollectionGenerator/README.md
+++ b/Sources/PackageCollectionGenerator/README.md
@@ -54,6 +54,7 @@ Each item in the `packages` array is a package object with the following fields:
 * `summary`: A description of the package. **Optional.**
 * `keywords`: An array of keywords that the package is associated with. **Optional.**
 * `versions`: An array of package versions to include. **Optional.** If not specified, the generate will select the most recent versions.
+* `excludedVersions`: An array of package versions to exclude. **Optional.** If a version is listed in both `versions` and `excludedVersions`, it will be excluded from the package collection. 
 * `excludedProducts`: An array of product names to exclude. **Optional.**
 * `excludedTargets`: An array of target names to exclude. **Optional.**
 * `readmeURL`: The URL of the package's README. **Optional.**

--- a/Tests/PackageCollectionGeneratorTests/Inputs/test-input.json
+++ b/Tests/PackageCollectionGeneratorTests/Inputs/test-input.json
@@ -8,6 +8,7 @@
       "summary": "Package Foobar",
       "keywords": ["test package"],
       "versions": ["0.2.0", "0.1.0"],
+      "excludedVersions": ["v0.1.0"],
       "excludedProducts": ["Foo"],
       "excludedTargets": ["Bar"],
       "readmeURL": "https://package-collection-tests.com/repos/foobar/README"

--- a/Tests/PackageCollectionGeneratorTests/PackageCollectionGeneratorInputTests.swift
+++ b/Tests/PackageCollectionGeneratorTests/PackageCollectionGeneratorInputTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Package Collection Generator open source project
 //
-// Copyright (c) 2020 Apple Inc. and the Swift Package Collection Generator project authors
+// Copyright (c) 2020-2021 Apple Inc. and the Swift Package Collection Generator project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -30,6 +30,7 @@ class PackageCollectionGeneratorInputTests: XCTestCase {
                     summary: "Package Foobar",
                     keywords: ["test package"],
                     versions: ["0.2.0", "0.1.0"],
+                    excludedVersions: ["v0.1.0"],
                     excludedProducts: ["Foo"],
                     excludedTargets: ["Bar"],
                     readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!
@@ -61,6 +62,7 @@ class PackageCollectionGeneratorInputTests: XCTestCase {
                     summary: "Package Foobar",
                     keywords: ["test package"],
                     versions: ["1.3.2"],
+                    excludedVersions: ["0.8.1"],
                     excludedProducts: ["Foo"],
                     excludedTargets: ["Bar"],
                     readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!


### PR DESCRIPTION
Motivation:
Currently a package's versions are determined by:
1. The latest versions in the git repository. This list changes automatically each time the generator runs.
2. A specific list of versions defined using `versions` in the generator input file. This requires manual update.

It would be nice if the generator supports a third option: "use the latetst versions except [versions]"

Modifications:
Add `excludedVersions` to generator input so that certain versions can be excluded of a collection regardless of how the generator computes the list  of package versions.