### PR TITLE
Improve diagnostics

### DIFF
--- a/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
+++ b/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
@@ -185,7 +185,12 @@ public struct PackageCollectionGenerate: ParsableCommand {
                                   gitDirectoryPath: AbsolutePath,
                                   metadataProvider: PackageMetadataProvider,
                                   jsonDecoder: JSONDecoder) throws -> Model.Collection.Package {
-        let additionalMetadata = try? tsc_await { callback in metadataProvider.get(package.url, callback: callback) }
+        var additionalMetadata: PackageBasicMetadata?
+        do {
+            additionalMetadata = try tsc_await { callback in metadataProvider.get(package.url, callback: callback) }
+        } catch {
+            printError("Failed to fetch additional metadata: \(error)")
+        }
         if let additionalMetadata = additionalMetadata {
             print("Retrieved additional metadata: \(additionalMetadata)", verbose: self.verbose)
         }

--- a/Sources/PackageCollectionGenerator/PackageMetadataProviders/GitHubPackageMetadataProvider.swift
+++ b/Sources/PackageCollectionGenerator/PackageMetadataProviders/GitHubPackageMetadataProvider.swift
@@ -139,7 +139,7 @@ struct GitHubPackageMetadataProvider: PackageMetadataProvider {
 
     private static func makeDefaultHTTPClient() -> HTTPClient {
         var client = HTTPClient()
-        client.configuration.requestTimeout = .seconds(1)
+        client.configuration.requestTimeout = .seconds(2)
         client.configuration.retryStrategy = .exponentialBackoff(maxAttempts: 3, baseDelay: .milliseconds(50))
         client.configuration.circuitBreakerStrategy = .hostErrors(maxErrors: 50, age: .seconds(30))
         return client


### PR DESCRIPTION
- Print error in case the generator fails to fetch additional metadata
- Increase GitHub API request timeout from 1s to 2s