### PR TITLE
Allow short -v verbose flag in all commands

### DIFF
--- a/Sources/PackageCollectionDiff/PackageCollectionDiff.swift
+++ b/Sources/PackageCollectionDiff/PackageCollectionDiff.swift
@@ -32,7 +32,7 @@ public struct PackageCollectionDiff: ParsableCommand {
     @Argument(help: "The path to the JSON document containing package collection #2")
     private var collectionTwoPath: String
 
-    @Flag(name: .long, help: "Show extra logging for debugging purposes")
+    @Flag(name: .shortAndLong, help: "Show extra logging for debugging purposes.")
     private var verbose: Bool = false
 
     typealias Model = PackageCollectionModel.V1

--- a/Sources/PackageCollectionDiff/README.md
+++ b/Sources/PackageCollectionDiff/README.md
@@ -13,6 +13,6 @@ ARGUMENTS:
   <collection-two-path>   The path to the JSON document containing package collection #2 
 
 OPTIONS:
-  --verbose               Show extra logging for debugging purposes 
+  -v, --verbose           Show extra logging for debugging purposes.
   -h, --help              Show help information.
 ```

--- a/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
+++ b/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
@@ -55,7 +55,7 @@ public struct PackageCollectionGenerate: ParsableCommand {
         """)
     private var authToken: [String] = []
 
-    @Flag(name: .long, help: "Show extra logging for debugging purposes")
+    @Flag(name: .shortAndLong, help: "Show extra logging for debugging purposes.")
     private var verbose: Bool = false
 
     typealias Model = PackageCollectionModel.V1

--- a/Sources/PackageCollectionGenerator/README.md
+++ b/Sources/PackageCollectionGenerator/README.md
@@ -27,7 +27,7 @@ OPTIONS:
   --auth-token <auth-token>
                           Auth tokens each in the format of type:host:token for retrieving additional package metadata via source
                           hosting platform APIs. Currently only GitHub APIs are supported. An example token would be github:github.com:<TOKEN>.   
-  --verbose               Show extra logging for debugging purposes 
+  -v, --verbose           Show extra logging for debugging purposes.
   -h, --help              Show help information.
 ```
 

--- a/Sources/PackageCollectionSigner/PackageCollectionSign.swift
+++ b/Sources/PackageCollectionSigner/PackageCollectionSign.swift
@@ -43,7 +43,7 @@ public struct PackageCollectionSign: ParsableCommand {
     @Argument(help: "Paths to all certificates (DER encoded) in the chain. The certificate used for signing must be first and the root certificate last.")
     var certChainPaths: [String]
 
-    @Flag(name: .long, help: "Show extra logging for debugging purposes")
+    @Flag(name: .shortAndLong, help: "Show extra logging for debugging purposes.")
     var verbose: Bool = false
 
     typealias Model = PackageCollectionModel.V1

--- a/Sources/PackageCollectionSigner/README.md
+++ b/Sources/PackageCollectionSigner/README.md
@@ -16,7 +16,7 @@ ARGUMENTS:
                           certificate last.
 
 OPTIONS:
-  --verbose               Show extra logging for debugging purposes
+  -v, --verbose           Show extra logging for debugging purposes.
   -h, --help              Show help information.
 ```
 

--- a/Sources/PackageCollectionValidator/PackageCollectionValidate.swift
+++ b/Sources/PackageCollectionValidator/PackageCollectionValidate.swift
@@ -34,7 +34,7 @@ public struct PackageCollectionValidate: ParsableCommand {
     @Flag(name: .long, help: "Warnings will fail validation in addition to errors")
     private var warningsAsErrors: Bool = false
 
-    @Flag(name: .long, help: "Show extra logging for debugging purposes")
+    @Flag(name: .shortAndLong, help: "Show extra logging for debugging purposes.")
     private var verbose: Bool = false
 
     typealias Model = PackageCollectionModel.V1

--- a/Sources/PackageCollectionValidator/README.md
+++ b/Sources/PackageCollectionValidator/README.md
@@ -13,6 +13,6 @@ ARGUMENTS:
 
 OPTIONS:
   --warnings-as-errors    Warnings will fail validation in addition to errors
-  --verbose               Show extra logging for debugging purposes
+  -v, --verbose           Show extra logging for debugging purposes.
   -h, --help              Show help information.
 ```


### PR DESCRIPTION
Allow short `-v` verbose flag in all commands, in addition to `--verbose`. The `-v` flag is well understood and allowing it in these commands matches what we already have for `-h`/`--help`.