### PR TITLE
Add hint to scripts/soundness.sh about swiftformat installation

### DIFF
--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -39,6 +39,10 @@ fi
 printf "\033[0;32mokay.\033[0m\n"
 
 printf "=> Checking format... "
+if [ -z `which swiftformat` ]; then
+  printf "\033[0;31mcould not find swiftformat. See https://github.com/nicklockwood/SwiftFormat for installation instructions.\033[0m\n"
+  exit 1
+fi
 FIRST_OUT="$(git status --porcelain)"
 swiftformat . > /dev/null 2>&1
 SECOND_OUT="$(git status --porcelain)"


### PR DESCRIPTION
Previously the script would exit ~silently if swiftformat was not installed.