### PR TITLE
Fix test in Linux and update docker builds

### DIFF
--- a/Tests/PackageCollectionGeneratorExecutableTests/PackageCollectionGenerateTests.swift
+++ b/Tests/PackageCollectionGeneratorExecutableTests/PackageCollectionGenerateTests.swift
@@ -175,6 +175,7 @@ final class PackageCollectionGenerateTests: XCTestCase {
                 ),
             ]
 
+            #if os(macOS) // XCTAttachment is available in Xcode only
             // Run command with both pretty-printed enabled and disabled (which is the default, with no flag).
             for prettyFlag in ["--pretty-printed", nil] {
                 // Where to write the generated collection
@@ -205,6 +206,7 @@ final class PackageCollectionGenerateTests: XCTestCase {
 
                 add(XCTAttachment(contentsOfFile: outputFilePath.asURL))
             }
+            #endif
         }
     }
 

--- a/docker/docker-compose.1804.54.yaml
+++ b/docker/docker-compose.1804.54.yaml
@@ -6,7 +6,8 @@ services:
     image: swift-package-collection-generator:18.04-5.4
     build:
       args:
-        base_image: "swiftlang/swift:nightly-5.4-bionic"
+        ubuntu_version: "bionic"
+        swift_version: "5.4"
 
   test:
     image: swift-package-collection-generator:18.04-5.4

--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -1,0 +1,17 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-package-collection-generator:20.04-5.5
+    build:
+      args:
+        base_image: "swiftlang/swift:nightly-5.5-focal"
+
+  test:
+    image: swift-package-collection-generator:20.04-5.5
+    environment: []
+      #- SANITIZER_ARG=--sanitize=thread
+
+  shell:
+    image: swift-package-collection-generator:20.04-5.5


### PR DESCRIPTION
- `XCTAttachment` is available through Xcode only, so skip the
pretty-print flag test when running on Linux.
- Update docker builds. Add 5.5.