### PR TITLE
Adopt new PackageCollectionSigner interface

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "0.3.0")),
         // FIXME: need semver
+        .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("main")),
         //        .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("release/5.5")),
-        .package(name: "SwiftPM", url: "https://github.com/finestructure/swift-package-manager.git", .branch("accept-private-key-as-data")),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", .upToNextMajor(from: "1.1.0")),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "0.3.0")),
         // FIXME: need semver
         .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("main")),
-        //        .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("release/5.5")),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", .upToNextMajor(from: "1.1.0")),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "0.3.0")),
         // FIXME: need semver
-        .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("main")),
+        //        .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git", .branch("release/5.5")),
+        .package(name: "SwiftPM", url: "https://github.com/finestructure/swift-package-manager.git", .branch("accept-private-key-as-data")),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", .upToNextMajor(from: "1.1.0")),
     ],
     targets: [

--- a/Tests/PackageCollectionSignerExecutableTests/PackageCollectionSignTests.swift
+++ b/Tests/PackageCollectionSignerExecutableTests/PackageCollectionSignTests.swift
@@ -62,7 +62,7 @@ final class PackageCollectionSignTests: XCTestCase {
 private struct MockPackageCollectionSigner: PackageCollectionSigner {
     func sign(collection: Model.Collection,
               certChainPaths: [URL],
-              certPrivateKeyPath: URL,
+              privateKeyPEM: Data,
               certPolicyKey: CertificatePolicyKey,
               callback: @escaping (Result<Model.SignedCollection, Error>) -> Void)
     {


### PR DESCRIPTION
Matching upstream changes suggested in https://github.com/apple/swift-package-manager/pull/3831