### PR TITLE
Add GitLab as metadata-provider and make it easier to support other ones

### DIFF
--- a/Sources/PackageCollectionGenerator/Models/PackageCollectionGeneratorInput.swift
+++ b/Sources/PackageCollectionGenerator/Models/PackageCollectionGeneratorInput.swift
@@ -30,6 +30,9 @@ public struct PackageCollectionGeneratorInput: Equatable, Codable {
     /// A list of packages to process.
     public let packages: [Package]
 
+    /// A mapping of the hosts to the corresponding metadata-provider (GitHub, GitLab, ...).
+    public let metadataProviderMapping: [String: String]?
+
     /// The author of this package collection.
     public let author: PackageCollectionModel.V1.Collection.Author?
 
@@ -38,12 +41,14 @@ public struct PackageCollectionGeneratorInput: Equatable, Codable {
         overview: String? = nil,
         keywords: [String]? = nil,
         packages: [Package],
+        metadataProviderMapping: [String: String]?,
         author: PackageCollectionModel.V1.Collection.Author? = nil
     ) {
         self.name = name
         self.overview = overview
         self.keywords = keywords
         self.packages = packages
+        self.metadataProviderMapping = metadataProviderMapping
         self.author = author
     }
 }
@@ -56,6 +61,7 @@ extension PackageCollectionGeneratorInput: CustomStringConvertible {
             overview=\(self.overview ?? "nil"),
             keywords=\(self.keywords.map { "\($0)" } ?? "nil"),
             packages=\(self.packages),
+            metadataProviderMapping=\(self.metadataProviderMapping.map { "\($0)" } ?? "nil"),
             author=\(self.author.map { "\($0)" } ?? "nil")
         }
         """

--- a/Sources/PackageCollectionGenerator/PackageMetadataProviders/GitLabPackageManagerMetadataProvider.swift
+++ b/Sources/PackageCollectionGenerator/PackageMetadataProviders/GitLabPackageManagerMetadataProvider.swift
@@ -1,0 +1,170 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift Package Collection Generator open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift Package Collection Generator project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Swift Package Collection Generator project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Dispatch
+import Foundation
+
+import TSCBasic
+import Basics
+import PackageCollectionsModel
+import Utilities
+
+struct GitLabPackageMetadataProvider: PackageMetadataProvider {
+    private static let apiHostURLPathPostfix = "api/v4"
+
+    private let authTokens: [AuthTokenType: String]
+    private let httpClient: HTTPClient
+    private let decoder: JSONDecoder
+    private enum ResultKeys {
+        case metadata
+    }
+
+    init(authTokens: [AuthTokenType: String] = [:], httpClient: HTTPClient? = nil) {
+        self.authTokens = authTokens
+        self.httpClient = httpClient ?? Self.makeDefaultHTTPClient()
+        self.decoder = JSONDecoder.makeWithDefaults()
+    }
+
+    func get(_ packageURL: URL, callback: @escaping (Result<PackageBasicMetadata, Error>) -> Void) {
+        guard let baseURL = self.apiURL(packageURL.absoluteString),
+              let urlComponents = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+                  return callback(.failure(Errors.invalidGitURL(packageURL)))
+              }
+
+        let projectPath = urlComponents.path.dropFirst().replacingOccurrences(of: "/", with: "%2F")
+        let apiPrefix = GitLabPackageMetadataProvider.apiHostURLPathPostfix
+        let metadataURL = URL(string: "\(urlComponents.scheme!)://\(urlComponents.host!)/\(apiPrefix)/projects/\(projectPath)")!
+
+        // get the main data
+        let metadataHeaders = HTTPClientHeaders()
+        let metadataOptions = self.makeRequestOptions(validResponseCodes: [200, 401, 403, 404])
+        let hasAuthorization = metadataOptions.authorizationProvider?(metadataURL) != nil
+        var result: Result<HTTPClient.Response, Error> = tsc_await { callback in self.httpClient.get(metadataURL, headers: metadataHeaders, options: metadataOptions, completion: callback) }
+
+        if case .success(let response) = result {
+            let apiLimit = response.headers.get("RateLimit-Limit").first.flatMap(Int.init) ?? -1
+            let apiRemaining = response.headers.get("RateLimit-Remaining").first.flatMap(Int.init) ?? -1
+            switch (response.statusCode, hasAuthorization, apiRemaining) {
+            case (_, _, 0):
+                result = .failure(Errors.apiLimitsExceeded(metadataURL, apiLimit, apiRemaining))
+            case (401, true, _):
+                result = .failure(Errors.invalidAuthToken(metadataURL))
+            case (401, false, _):
+                result = .failure(Errors.permissionDenied(metadataURL))
+            case (403, _, _):
+                result = .failure(Errors.permissionDenied(metadataURL))
+            case (404, _, _):
+                result = .failure(Errors.notFound(metadataURL))
+            case (200, _, _):
+                guard let metadata = try? response.decodeBody(GetRepositoryResponse.self, using: self.decoder) else {
+                    callback(.failure(Errors.invalidResponse(metadataURL, "Invalid body")))
+                    return
+                }
+
+                let license = metadata.license
+                let packageLicense: PackageCollectionModel.V1.License?
+                if let license = license {
+                    packageLicense = .init(name: license.name, url: license.sourceURL)
+                } else if let licenseURL = metadata.license_url,
+                    let licenseURL = URL(string: licenseURL) {
+                    packageLicense = .init(name: nil, url: licenseURL)
+                } else {
+                    packageLicense = nil
+                }
+
+                let model = PackageBasicMetadata(
+                    summary: metadata.description,
+                    keywords: metadata.topics,
+                    readmeURL: metadata.readme_url.flatMap { URL(string: $0) },
+                    license: packageLicense
+                )
+
+                callback(.success(model))
+            default:
+                callback(.failure(Errors.invalidResponse(metadataURL, "Invalid status code: \(response.statusCode)")))
+            }
+        }
+    }
+
+    internal func apiURL(_ url: String) -> Foundation.URL? {
+        return URL(string: url.spm_dropGitSuffix())
+    }
+
+    private func makeRequestOptions(validResponseCodes: [Int]) -> HTTPClientRequest.Options {
+        var options = HTTPClientRequest.Options()
+        options.addUserAgent = true
+        options.validResponseCodes = validResponseCodes
+        options.authorizationProvider = { url in
+            url.host.flatMap { host in
+                return self.authTokens[.gitlab(host)].flatMap { token in "Bearer \(token)" }
+            }
+        }
+        return options
+    }
+
+    private static func makeDefaultHTTPClient() -> HTTPClient {
+        var client = HTTPClient()
+        client.configuration.requestTimeout = .seconds(2)
+        client.configuration.retryStrategy = .exponentialBackoff(maxAttempts: 3, baseDelay: .milliseconds(50))
+        client.configuration.circuitBreakerStrategy = .hostErrors(maxErrors: 50, age: .seconds(30))
+        return client
+    }
+
+    enum Errors: Error, Equatable {
+        case invalidGitURL(URL)
+        case invalidResponse(URL, String)
+        case permissionDenied(URL)
+        case invalidAuthToken(URL)
+        case apiLimitsExceeded(URL, Int, Int)
+        case notFound(URL)
+    }
+}
+
+extension GitLabPackageMetadataProvider {
+    fileprivate struct GetRepositoryResponse: Codable {
+        let name: String
+        let fullName: String
+        let description: String?
+        let topics: [String]?
+        let license_url: String?
+        let readme_url: String?
+        let license: License?
+
+        private enum CodingKeys: String, CodingKey {
+            case name
+            case fullName = "name_with_namespace"
+            case description
+            case topics
+            case license_url
+            case readme_url
+            case license
+        }
+    }
+}
+
+extension GitLabPackageMetadataProvider {
+    fileprivate struct License: Codable {
+        let htmlURL: Foundation.URL
+        let sourceURL: Foundation.URL
+        let nickname: String?
+        let name: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case htmlURL = "html_url"
+            case sourceURL = "source_url"
+            case nickname
+            case name
+        }
+    }
+}

--- a/Sources/PackageCollectionGenerator/PackageMetadataProviders/PackageMetadataProvider.swift
+++ b/Sources/PackageCollectionGenerator/PackageMetadataProviders/PackageMetadataProvider.swift
@@ -22,11 +22,14 @@ protocol PackageMetadataProvider {
 
 enum AuthTokenType: Hashable, CustomStringConvertible {
     case github(_ host: String)
+    case gitlab(_ host: String)
 
     var description: String {
         switch self {
         case .github(let host):
             return "github(\(host))"
+        case .gitlab(let host):
+            return "gitlab(\(host))"
         }
     }
 
@@ -34,6 +37,8 @@ enum AuthTokenType: Hashable, CustomStringConvertible {
         switch type {
         case "github":
             return .github(host)
+        case "gitlab":
+            return .gitlab(host)
         default:
             return nil
         }

--- a/Sources/PackageCollectionGenerator/README.md
+++ b/Sources/PackageCollectionGenerator/README.md
@@ -47,6 +47,7 @@ Collection metadata:
 * `keywords`: An array of keywords that the collection is associated with. **Optional.**
 * `author`: The author of this package collection. **Optional.**
     * `name`: The author name.
+* `metadataProviderMapping`: A dictionary describing a mapping from hosts to metadata-provider (github / gitlab). **Optional.**
 * `packages`: An array of package objects.
 
 Each item in the `packages` array is a package object with the following fields:
@@ -81,6 +82,9 @@ Each item in the `packages` array is a package object with the following fields:
       "url": "https://www.example.com/repos/RepoTwo.git"
     }
   ],
+  "metadataProviderMapping": {
+    "www.example.com": "gitlab"
+  }
   "author": {
     "name": "Jane Doe"
   }

--- a/Tests/PackageCollectionGeneratorExecutableTests/PackageCollectionGenerateTests.swift
+++ b/Tests/PackageCollectionGeneratorExecutableTests/PackageCollectionGenerateTests.swift
@@ -64,7 +64,8 @@ final class PackageCollectionGenerateTests: XCTestCase {
                         summary: "Package Baz",
                         versions: ["1.0.0"]
                     ),
-                ]
+                ],
+                metadataProviderMapping: ["package-collection-tests.com": "github"]
             )
             let jsonEncoder = JSONEncoder.makeWithDefaults()
             let inputData = try jsonEncoder.encode(input)
@@ -235,7 +236,8 @@ final class PackageCollectionGenerateTests: XCTestCase {
                         summary: "Package Foo & Bar",
                         excludedVersions: ["0.1.0"]
                     ),
-                ]
+                ],
+                metadataProviderMapping: ["package-collection-tests.com": "github"]
             )
             let jsonEncoder = JSONEncoder.makeWithDefaults()
             let inputData = try jsonEncoder.encode(input)

--- a/Tests/PackageCollectionGeneratorTests/Inputs/test-input.json
+++ b/Tests/PackageCollectionGeneratorTests/Inputs/test-input.json
@@ -17,6 +17,9 @@
       "url": "https://package-collection-tests.com/repos/foobaz.git"
     }
   ],
+  "metadataProviderMapping": {
+      "package-collection-tests.com": "github"
+  },
   "author": {
     "name": "Jane Doe"
   }

--- a/Tests/PackageCollectionGeneratorTests/PackageCollectionGeneratorInputTests.swift
+++ b/Tests/PackageCollectionGeneratorTests/PackageCollectionGeneratorInputTests.swift
@@ -39,6 +39,7 @@ class PackageCollectionGeneratorInputTests: XCTestCase {
                     url: URL(string: "https://package-collection-tests.com/repos/foobaz.git")!
                 ),
             ],
+            metadataProviderMapping: ["package-collection-tests.com": "github"],
             author: .init(name: "Jane Doe")
         )
 
@@ -68,6 +69,7 @@ class PackageCollectionGeneratorInputTests: XCTestCase {
                     readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!
                 ),
             ],
+            metadataProviderMapping: ["package-collection-tests.com": "github"],
             author: .init(name: "Jane Doe")
         )
 


### PR DESCRIPTION
This is the implementation based on my suggestion in https://forums.swift.org/t/pitch-package-collection-generator-supporting-multiple-git-hoster/53834/2.
Introducing a new field in the input.json to specify which metadata-provider should be used for a certain host.
Currently supported are github and gitlab. A default-mapping for the hosts github.com and gitlab.com is given.

Not sure if `metadataProviderMapping` for the input.json is descriptive enough, I'm open for suggestions. 