### PR TITLE
Fix Process.verbose deprecation warnings

### DIFF
--- a/Sources/PackageCollectionDiff/PackageCollectionDiff.swift
+++ b/Sources/PackageCollectionDiff/PackageCollectionDiff.swift
@@ -41,7 +41,6 @@ public struct PackageCollectionDiff: ParsableCommand {
 
     public func run() throws {
         Backtrace.install()
-        Process.verbose = self.verbose
 
         print("Comparing collections located at \(self.collectionOnePath) and \(self.collectionTwoPath)", inColor: .cyan, verbose: self.verbose)
 

--- a/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
+++ b/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
@@ -67,7 +67,6 @@ public struct PackageCollectionGenerate: ParsableCommand {
 
     public func run() throws {
         Backtrace.install()
-        Process.verbose = self.verbose
 
         // Parse auth tokens
         let authTokens = self.authToken.reduce(into: [AuthTokenType: String]()) { authTokens, authToken in

--- a/Sources/PackageCollectionSigner/PackageCollectionSign.swift
+++ b/Sources/PackageCollectionSigner/PackageCollectionSign.swift
@@ -62,8 +62,6 @@ public struct PackageCollectionSign: ParsableCommand {
             throw PackageCollectionSigningError.emptyCertChain
         }
 
-        Process.verbose = self.verbose
-
         print("Signing package collection located at \(self.inputPath)", inColor: .cyan, verbose: self.verbose)
 
         let jsonDecoder = JSONDecoder.makeWithDefaults()

--- a/Sources/PackageCollectionValidator/PackageCollectionValidate.swift
+++ b/Sources/PackageCollectionValidator/PackageCollectionValidate.swift
@@ -43,7 +43,6 @@ public struct PackageCollectionValidate: ParsableCommand {
 
     public func run() throws {
         Backtrace.install()
-        Process.verbose = self.verbose
 
         print("Using input file located at \(self.inputPath)", inColor: .cyan, verbose: self.verbose)
 


### PR DESCRIPTION
Remove `Process.verbose = self.verbose` since it's not really needed by
the commands.