### PR TITLE
Add package 'signer' to input

### DIFF
--- a/Sources/PackageCollectionGenerator/Models/PackageCollectionGeneratorInput.swift
+++ b/Sources/PackageCollectionGenerator/Models/PackageCollectionGeneratorInput.swift
@@ -94,6 +94,8 @@ public extension PackageCollectionGeneratorInput {
 
         /// The URL of the package's README.
         public let readmeURL: URL?
+        
+        public let signer: PackageCollectionModel.V1.Signer?
 
         public init(
             url: URL,
@@ -104,7 +106,8 @@ public extension PackageCollectionGeneratorInput {
             excludedVersions: [String]? = nil,
             excludedProducts: [String]? = nil,
             excludedTargets: [String]? = nil,
-            readmeURL: URL? = nil
+            readmeURL: URL? = nil,
+            signer: PackageCollectionModel.V1.Signer? = nil
         ) {
             self.url = url
             self.identity = identity
@@ -115,6 +118,7 @@ public extension PackageCollectionGeneratorInput {
             self.excludedProducts = excludedProducts
             self.excludedTargets = excludedTargets
             self.readmeURL = readmeURL
+            self.signer = signer
         }
     }
 }
@@ -131,7 +135,8 @@ extension PackageCollectionGeneratorInput.Package: CustomStringConvertible {
                 excludedVersions=\(self.excludedVersions.map { "\($0)" } ?? "nil"),
                 excludedProducts=\(self.excludedProducts.map { "\($0)" } ?? "nil"),
                 excludedTargets=\(self.excludedTargets.map { "\($0)" } ?? "nil"),
-                readmeURL=\(self.readmeURL.map { "\($0)" } ?? "nil")
+                readmeURL=\(self.readmeURL.map { "\($0)" } ?? "nil"),
+                signer=\(self.signer.map { "\($0)" } ?? "nil")
             }
         """
     }

--- a/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
+++ b/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
@@ -233,6 +233,7 @@ public struct PackageCollectionGenerate: ParsableCommand {
                     for: version,
                     excludedProducts: package.excludedProducts.map { Set($0) } ?? [],
                     excludedTargets: package.excludedTargets.map { Set($0) } ?? [],
+                    signer: package.signer,
                     gitDirectoryPath: gitDirectoryPath,
                     jsonDecoder: jsonDecoder
                 )
@@ -266,6 +267,7 @@ public struct PackageCollectionGenerate: ParsableCommand {
     private func generateMetadata(for version: String,
                                   excludedProducts: Set<String>,
                                   excludedTargets: Set<String>,
+                                  signer: PackageCollectionModel.V1.Signer?,
                                   gitDirectoryPath: AbsolutePath,
                                   jsonDecoder: JSONDecoder) throws -> Model.Collection.Package.Version
     {
@@ -291,6 +293,8 @@ public struct PackageCollectionGenerate: ParsableCommand {
             defaultToolsVersion: defaultManifest.toolsVersion,
             verifiedCompatibility: nil,
             license: nil,
+            author: nil,
+            signer: signer,
             createdAt: gitTagInfo?.createdAt
         )
     }

--- a/Tests/PackageCollectionGeneratorTests/Inputs/test-input.json
+++ b/Tests/PackageCollectionGeneratorTests/Inputs/test-input.json
@@ -12,7 +12,13 @@
       "excludedVersions": ["v0.1.0"],
       "excludedProducts": ["Foo"],
       "excludedTargets": ["Bar"],
-      "readmeURL": "https://package-collection-tests.com/repos/foobar/README"
+      "readmeURL": "https://package-collection-tests.com/repos/foobar/README",
+      "signer": {
+        "type": "ADP",
+        "commonName": "J. Appleseed",
+        "organizationalUnitName": "A1",
+        "organizationName": "Appleseed Inc."
+      }
     },
     {
       "url": "https://package-collection-tests.com/repos/foobaz.git"

--- a/Tests/PackageCollectionGeneratorTests/PackageCollectionGenerateTests.swift
+++ b/Tests/PackageCollectionGeneratorTests/PackageCollectionGenerateTests.swift
@@ -45,6 +45,13 @@ final class PackageCollectionGenerateTests: XCTestCase {
             let repoThreeArchivePath = try AbsolutePath(validating: #file).parentDirectory.appending(components: "Inputs", "TestRepoThree.tgz")
             try systemQuietly(["tar", "-x", "-v", "-C", tmpDir.pathString, "-f", repoThreeArchivePath.pathString])
 
+            let signer = PackageCollectionModel.V1.Signer(
+                type: "ADP",
+                commonName: "J. Appleseed",
+                organizationalUnitName: "A1",
+                organizationName: "Appleseed Inc."
+            )
+
             // Prepare input.json
             let input = PackageCollectionGeneratorInput(
                 name: "Test Package Collection",
@@ -58,7 +65,8 @@ final class PackageCollectionGenerateTests: XCTestCase {
                     PackageCollectionGeneratorInput.Package(
                         url: URL(string: "https://package-collection-tests.com/repos/TestRepoTwo.git")!,
                         identity: "repos.two",
-                        summary: "Package Foo & Bar"
+                        summary: "Package Foo & Bar",
+                        signer: signer
                     ),
                     PackageCollectionGeneratorInput.Package(
                         url: URL(string: "https://package-collection-tests.com/repos/TestRepoThree.git")!,
@@ -93,6 +101,8 @@ final class PackageCollectionGenerateTests: XCTestCase {
                             defaultToolsVersion: "5.2",
                             verifiedCompatibility: nil,
                             license: nil,
+                            author: nil,
+                            signer: nil,
                             createdAt: nil
                         ),
                     ],
@@ -126,6 +136,8 @@ final class PackageCollectionGenerateTests: XCTestCase {
                             defaultToolsVersion: "5.2",
                             verifiedCompatibility: nil,
                             license: nil,
+                            author: nil,
+                            signer: signer,
                             createdAt: nil
                         ),
                         Model.Collection.Package.Version(
@@ -143,6 +155,8 @@ final class PackageCollectionGenerateTests: XCTestCase {
                             defaultToolsVersion: "5.2",
                             verifiedCompatibility: nil,
                             license: nil,
+                            author: nil,
+                            signer: signer,
                             createdAt: nil
                         ),
                     ],
@@ -169,6 +183,8 @@ final class PackageCollectionGenerateTests: XCTestCase {
                             defaultToolsVersion: "5.2",
                             verifiedCompatibility: nil,
                             license: nil,
+                            author: nil,
+                            signer: nil,
                             createdAt: nil
                         ),
                     ],
@@ -280,6 +296,8 @@ final class PackageCollectionGenerateTests: XCTestCase {
                             defaultToolsVersion: "5.2",
                             verifiedCompatibility: nil,
                             license: nil,
+                            author: nil,
+                            signer: nil,
                             createdAt: nil
                         ),
                     ],
@@ -313,6 +331,8 @@ final class PackageCollectionGenerateTests: XCTestCase {
                             defaultToolsVersion: "5.2",
                             verifiedCompatibility: nil,
                             license: nil,
+                            author: nil,
+                            signer: nil,
                             createdAt: nil
                         ),
                     ],

--- a/Tests/PackageCollectionGeneratorTests/PackageCollectionGeneratorInputTests.swift
+++ b/Tests/PackageCollectionGeneratorTests/PackageCollectionGeneratorInputTests.swift
@@ -16,6 +16,7 @@ import Foundation
 import XCTest
 
 @testable import PackageCollectionGenerator
+import PackageCollectionsModel
 import TSCBasic
 
 class PackageCollectionGeneratorInputTests: XCTestCase {
@@ -34,7 +35,8 @@ class PackageCollectionGeneratorInputTests: XCTestCase {
                     excludedVersions: ["v0.1.0"],
                     excludedProducts: ["Foo"],
                     excludedTargets: ["Bar"],
-                    readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!
+                    readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!,
+                    signer: .init(type: "ADP", commonName: "J. Appleseed", organizationalUnitName: "A1", organizationName: "Appleseed Inc.")
                 ),
                 PackageCollectionGeneratorInput.Package(
                     url: URL(string: "https://package-collection-tests.com/repos/foobaz.git")!
@@ -67,7 +69,8 @@ class PackageCollectionGeneratorInputTests: XCTestCase {
                     excludedVersions: ["0.8.1"],
                     excludedProducts: ["Foo"],
                     excludedTargets: ["Bar"],
-                    readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!
+                    readmeURL: URL(string: "https://package-collection-tests.com/repos/foobar/README")!,
+                    signer: .init(type: "ADP", commonName: "J. Appleseed", organizationalUnitName: "A1", organizationName: "Appleseed Inc.")
                 ),
             ],
             author: .init(name: "Jane Doe")


### PR DESCRIPTION
Motivation:
A package version in a package collection can have `signer`, which was added https://github.com/apple/swift-package-manager/pull/6415

Modification:
Add `signer` to package level input. If set, all versions of the package will have that `signer`.