### PR TITLE
Adjust code to use Basics API rather than TSC

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,6 @@ import PackageDescription
 
 let package = Package(
     name: "swift-package-collection-generator",
-    // Required for JSONEncoder/Decoder formatting and ISO-8601 support
     platforms: [.macOS(.v12)],
     products: [
         .executable(name: "package-collection-generate", targets: ["PackageCollectionGenerator"]),

--- a/Sources/PackageCollectionDiff/PackageCollectionDiff.swift
+++ b/Sources/PackageCollectionDiff/PackageCollectionDiff.swift
@@ -18,7 +18,6 @@ import Foundation
 import Backtrace
 import Basics
 import PackageCollectionsModel
-import TSCBasic
 import Utilities
 
 @main

--- a/Sources/PackageCollectionGenerator/Models/PackageCollectionGeneratorInput.swift
+++ b/Sources/PackageCollectionGenerator/Models/PackageCollectionGeneratorInput.swift
@@ -67,7 +67,7 @@ public extension PackageCollectionGeneratorInput {
     struct Package: Equatable, Codable {
         /// The URL of the package. Currently only Git repository URLs are supported.
         public let url: URL
-        
+
         /// The identity of the package if published to registry.
         public let identity: String?
 
@@ -94,7 +94,7 @@ public extension PackageCollectionGeneratorInput {
 
         /// The URL of the package's README.
         public let readmeURL: URL?
-        
+
         public let signer: PackageCollectionModel.V1.Signer?
 
         public init(

--- a/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
+++ b/Sources/PackageCollectionGenerator/PackageCollectionGenerate.swift
@@ -19,7 +19,6 @@ import Backtrace
 import Basics
 import PackageCollectionsModel
 import PackageModel
-import TSCBasic
 import TSCUtility
 import Utilities
 
@@ -208,7 +207,7 @@ public struct PackageCollectionGenerate: ParsableCommand {
                                   jsonDecoder: JSONDecoder) throws -> Model.Collection.Package {
         var additionalMetadata: PackageBasicMetadata?
         do {
-            additionalMetadata = try tsc_await { callback in metadataProvider.get(package.url, callback: callback) }
+            additionalMetadata = try temp_await { callback in metadataProvider.get(package.url, callback: callback) }
         } catch {
             printError("Failed to fetch additional metadata: \(error)")
         }

--- a/Sources/PackageCollectionSigner/PackageCollectionSign.swift
+++ b/Sources/PackageCollectionSigner/PackageCollectionSign.swift
@@ -22,8 +22,6 @@ import Backtrace
 import Basics
 import PackageCollectionsModel
 import PackageCollectionsSigning
-
-import TSCBasic
 import Utilities
 
 @main
@@ -82,7 +80,7 @@ public struct PackageCollectionSign: ParsableCommand {
             let signer = signer ?? PackageCollectionSigning(trustedRootCertsDir: tmpDir.asURL,
                                                             observabilityScope: ObservabilitySystem { _, diagnostic in print(diagnostic) }.topScope,
                                                             callbackQueue: DispatchQueue.global())
-            let signedCollection = try tsc_await { callback in
+            let signedCollection = try temp_await { callback in
                 signer.sign(collection: collection, certChainPaths: certChainURLs, certPrivateKeyPath: privateKeyURL, certPolicyKey: .default, callback: callback)
             }
 

--- a/Sources/PackageCollectionValidator/PackageCollectionValidate.swift
+++ b/Sources/PackageCollectionValidator/PackageCollectionValidate.swift
@@ -20,7 +20,6 @@ import Basics
 import enum PackageCollections.ValidationError
 import struct PackageCollections.ValidationMessage
 import enum PackageCollectionsModel.PackageCollectionModel
-import TSCBasic
 import Utilities
 
 @main

--- a/Sources/Utilities/Git.swift
+++ b/Sources/Utilities/Git.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift Package Collection Generator open source project
 //
-// Copyright (c) 2020-2021 Apple Inc. and the Swift Package Collection Generator project authors
+// Copyright (c) 2020-2023 Apple Inc. and the Swift Package Collection Generator project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -14,7 +14,7 @@
 
 import Foundation
 
-import TSCBasic
+import Basics
 import TSCUtility
 
 public enum GitUtilities {

--- a/Sources/Utilities/Path.swift
+++ b/Sources/Utilities/Path.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Basics
 import Foundation
-import TSCBasic
 
 public func ensureAbsolute(path: String) throws -> AbsolutePath {
     do {

--- a/Tests/PackageCollectionDiffTests/PackageCollectionDiffTests.swift
+++ b/Tests/PackageCollectionDiffTests/PackageCollectionDiffTests.swift
@@ -14,9 +14,9 @@
 
 import XCTest
 
+import Basics
 @testable import PackageCollectionDiff
 @testable import TestUtilities
-import TSCBasic
 
 final class PackageCollectionDiffTests: XCTestCase {
     func test_help() throws {

--- a/Tests/PackageCollectionGeneratorTests/GitHubPackageMetadataProviderTests.swift
+++ b/Tests/PackageCollectionGeneratorTests/GitHubPackageMetadataProviderTests.swift
@@ -17,7 +17,7 @@ import XCTest
 
 import Basics
 @testable import PackageCollectionGenerator
-import TSCBasic
+import enum TSCBasic.ProcessEnv
 
 final class GitHubPackageMetadataProviderTests: XCTestCase {
     func test_apiURL() throws {
@@ -78,7 +78,7 @@ final class GitHubPackageMetadataProviderTests: XCTestCase {
         httpClient.configuration.retryStrategy = .none
 
         let provider = GitHubPackageMetadataProvider(authTokens: authTokens, httpClient: httpClient)
-        let metadata = try tsc_await { callback in provider.get(repoURL, callback: callback) }
+        let metadata = try temp_await { callback in provider.get(repoURL, callback: callback) }
 
         XCTAssertEqual("This your first repo!", metadata.summary)
         XCTAssertEqual(["octocat", "atom", "electron", "api"], metadata.keywords)
@@ -106,7 +106,7 @@ final class GitHubPackageMetadataProviderTests: XCTestCase {
         httpClient.configuration.retryStrategy = .none
 
         let provider = GitHubPackageMetadataProvider(authTokens: authTokens, httpClient: httpClient)
-        XCTAssertThrowsError(try tsc_await { callback in provider.get(repoURL, callback: callback) }, "should throw error") { error in
+        XCTAssertThrowsError(try temp_await { callback in provider.get(repoURL, callback: callback) }, "should throw error") { error in
             XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .invalidAuthToken(apiURL))
         }
     }
@@ -125,7 +125,7 @@ final class GitHubPackageMetadataProviderTests: XCTestCase {
         httpClient.configuration.retryStrategy = .none
 
         let provider = GitHubPackageMetadataProvider(authTokens: authTokens, httpClient: httpClient)
-        XCTAssertThrowsError(try tsc_await { callback in provider.get(repoURL, callback: callback) }, "should throw error") { error in
+        XCTAssertThrowsError(try temp_await { callback in provider.get(repoURL, callback: callback) }, "should throw error") { error in
             XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .notFound(apiURL))
         }
     }
@@ -156,7 +156,7 @@ final class GitHubPackageMetadataProviderTests: XCTestCase {
         httpClient.configuration.retryStrategy = .none
 
         let provider = GitHubPackageMetadataProvider(authTokens: authTokens, httpClient: httpClient)
-        let metadata = try tsc_await { callback in provider.get(repoURL, callback: callback) }
+        let metadata = try temp_await { callback in provider.get(repoURL, callback: callback) }
 
         XCTAssertEqual("This your first repo!", metadata.summary)
         XCTAssertEqual(["octocat", "atom", "electron", "api"], metadata.keywords)
@@ -177,7 +177,7 @@ final class GitHubPackageMetadataProviderTests: XCTestCase {
         httpClient.configuration.retryStrategy = .none
 
         let provider = GitHubPackageMetadataProvider(httpClient: httpClient)
-        XCTAssertThrowsError(try tsc_await { callback in provider.get(repoURL, callback: callback) }, "should throw error") { error in
+        XCTAssertThrowsError(try temp_await { callback in provider.get(repoURL, callback: callback) }, "should throw error") { error in
             XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .permissionDenied(apiURL))
         }
     }
@@ -185,7 +185,7 @@ final class GitHubPackageMetadataProviderTests: XCTestCase {
     func testInvalidURL() throws {
         let repoURL = URL(string: "/")!
         let provider = GitHubPackageMetadataProvider()
-        XCTAssertThrowsError(try tsc_await { callback in provider.get(repoURL, callback: callback) }, "should throw error") { error in
+        XCTAssertThrowsError(try temp_await { callback in provider.get(repoURL, callback: callback) }, "should throw error") { error in
             XCTAssertEqual(error as? GitHubPackageMetadataProvider.Errors, .invalidGitURL(repoURL))
         }
     }
@@ -211,7 +211,7 @@ final class GitHubPackageMetadataProviderTests: XCTestCase {
 
         let provider = GitHubPackageMetadataProvider(authTokens: authTokens, httpClient: httpClient)
         for _ in 0 ... 60 {
-            let metadata = try tsc_await { callback in provider.get(repoURL, callback: callback) }
+            let metadata = try temp_await { callback in provider.get(repoURL, callback: callback) }
             XCTAssertNotNil(metadata)
             XCTAssert(metadata.keywords!.count > 0)
             XCTAssertNotNil(metadata.readmeURL)

--- a/Tests/PackageCollectionGeneratorTests/PackageCollectionGenerateTests.swift
+++ b/Tests/PackageCollectionGeneratorTests/PackageCollectionGenerateTests.swift
@@ -19,7 +19,7 @@ import Basics
 @testable import PackageCollectionGenerator
 import PackageCollectionsModel
 @testable import TestUtilities
-import TSCBasic
+import struct TSCBasic.ByteString
 import TSCUtility
 
 final class PackageCollectionGenerateTests: XCTestCase {

--- a/Tests/PackageCollectionGeneratorTests/PackageCollectionGeneratorInputTests.swift
+++ b/Tests/PackageCollectionGeneratorTests/PackageCollectionGeneratorInputTests.swift
@@ -15,9 +15,9 @@
 import Foundation
 import XCTest
 
+import Basics
 @testable import PackageCollectionGenerator
 import PackageCollectionsModel
-import TSCBasic
 
 class PackageCollectionGeneratorInputTests: XCTestCase {
     func testLoadFromFile() throws {

--- a/Tests/PackageCollectionSignerTests/PackageCollectionSignTests.swift
+++ b/Tests/PackageCollectionSignerTests/PackageCollectionSignTests.swift
@@ -20,7 +20,6 @@ import Basics
 import PackageCollectionsModel
 import PackageCollectionsSigning
 @testable import TestUtilities
-import TSCBasic
 
 private typealias Model = PackageCollectionModel.V1
 

--- a/Tests/PackageCollectionValidatorTests/PackageCollectionValidateTests.swift
+++ b/Tests/PackageCollectionValidatorTests/PackageCollectionValidateTests.swift
@@ -14,9 +14,9 @@
 
 import XCTest
 
+import Basics
 @testable import PackageCollectionValidator
 @testable import TestUtilities
-import TSCBasic
 
 final class PackageCollectionValidateTests: XCTestCase {
     func test_help() throws {


### PR DESCRIPTION
SwiftPM has its versions of `AbsolutePath` and `withTemporaryDirectory`, causing ambiguous call errors.